### PR TITLE
Release 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,3 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "mysql:mysql-connector-java"
-    versions: ">=6.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.xdev-software</groupId>
 	<artifactId>xapi-db-mysql-5</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>5.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>SqlEngine Database Adapter MySQL 5</name>


### PR DESCRIPTION
Starting with 5.0.0 instead of 1.0.0 to keep it consistent with the current XDEV IDE / XAPI version